### PR TITLE
Use multi-stage Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,9 @@
+FROM rust:jessie
+RUN rustup target add i686-unknown-linux-musl
+COPY src /src
+COPY Cargo.toml /
+RUN cargo build --target i686-unknown-linux-musl --release
+
 FROM scratch
-COPY target/i686-unknown-linux-musl/release/rust-cv /
+COPY --from=0 target/i686-unknown-linux-musl/release/rust-cv /
 CMD ["/rust-cv"]

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Rust application that shows my resume in a terminal UI fashion
 You can run it locally with `docker run -it maitesin/resume`
 
 
-## How to build the application to be statically linked
+## How to build the application locally
 
 ```
 rustup target add i686-unknown-linux-musl
@@ -18,8 +18,10 @@ cargo build --target i686-unknown-linux-musl --release
 ## Build the Docker image
 
 ```
-docker build -t resume .
-docker tag resume maitesin/resume
+docker build -t DOCKER_HUB_USERNAME/resume .
+docker tag resume DOCKER_HUB_USERNAME/resume
 docker login
-docker push maitesin/resume
+docker push DOCKER_HUB_USERNAME/resume
 ```
+
+Or set up an automated build on the Docker Hub!


### PR DESCRIPTION
I modified the Dockerfile to use a multi-stage build, so that one doesn't have to run `rustup`/`cargo` locally to build the image (and so an automated build on the Docker Hub can still be tiny).